### PR TITLE
Fix signalling issues with Pterodactyl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ LABEL maintainer="Dark <dark@zexade.com>"
 LABEL maintainer="Jamie <jamie@falconhosting.co.uk>"
 
 COPY ./entrypoint.sh /entrypoint.sh
+COPY ./dashactyl.sh /dashactyl.sh
 
 RUN apk add --update --no-cache git && \
     adduser -D -h /home/container container && \
-    chmod +x /entrypoint.sh
+    chmod +x /entrypoint.sh && \
+    chmod +x /dashactyl.sh
 
 USER container
 ENV HOME=/home/container USER=container

--- a/dashactyl.sh
+++ b/dashactyl.sh
@@ -26,7 +26,7 @@ else
 		exit 0
 	;;
 	*)
-		exit 0
+		exit 1
 	;;
 	esac
 

--- a/dashactyl.sh
+++ b/dashactyl.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+if [ -f "/home/container/index.js" ]; then
+	node index.js
+else
+
+  	echo "index.js not found. Proceed to install Dashactyl V2? (Y/N)"
+
+	read -r USER_INPUT
+
+	USER_INPUT=$(printf "%s" "$USER_INPUT" | tr '[:upper:]' '[:lower:]')
+
+	case "$USER_INPUT" in
+	y|yes)
+		echo "Installing Dashactyl"
+
+	    git clone --branch stable https://github.com/Votion-Development/Dashactyl.git /home/container/Dashactyl
+        mv /home/container/Dashactyl/** /home/container
+        rm -rf /home/container/Dashactyl
+        mv /home/container/webconfig-example.yml /home/container/webconfig.yml
+
+		yarn install
+		echo "Dashactyl is now installed. Please open webconfig.yml and follow the guide to fill out the details: https://docs.votion.dev/docs/Dashactyl/configuration";
+	;;
+	n|no)
+		exit 0
+	;;
+	*)
+		exit 0
+	;;
+	esac
+
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,32 +1,3 @@
 #! /bin/sh
 
-cd /home/container || exit 1;
-
-if [[ -f "/home/container/index.js" ]]; then
-  node index.js
-else
-  echo "index.js not found. Proceed to install Dashactyl V2? (Y/N)";
-  read proceed;
-
-  case "$proceed" in
-    "Y"|"y")
-        echo "Installing Dashactyl...";
-
-        git clone --branch stable https://github.com/Votion-Development/Dashactyl.git /home/container/Dashactyl
-        mv /home/container/Dashactyl/** /home/container
-        rm -rf /home/container/Dashactyl
-        mv /home/container/webconfig-example.yml /home/container/webconfig.yml
-
-        yarn install
-
-        echo "Dashactyl is now installed. Please open webconfig.yml and follow the guide to fill out the details: https://docs.votion.dev/docs/Dashactyl/configuration";
-        exit 0;
-        ;;
-    "N"|"n")
-        exit 0;
-        ;;
-    *)
-        exit 1;
-        ;;
-    esac
-fi
+exec env /dashactyl.sh


### PR DESCRIPTION
This fixes some issues with signalling, as with the current egg, ^C doesn't work without having `exec env` in the entrypoint script.